### PR TITLE
feat: Implement dark mode and adjust hero section text size

### DIFF
--- a/components/sections/hero.section.tsx
+++ b/components/sections/hero.section.tsx
@@ -46,9 +46,9 @@ export default function HeroSection() {
               className="group"
             >
               {item.comingSoon ? (
-                <div className="flex items-center justify-between border-b border-white/30 hover:border-white/60 transition-all duration-300 min-w-[220px] sm:min-w-[260px] md:min-w-[280px] cursor-default">
+                <div className="flex text:xs md:text-md items-center justify-between border-b border-white/30 hover:border-white/60 transition-all duration-300 min-w-[220px] sm:min-w-[260px] md:min-w-[280px] cursor-default">
                   {item.label}
-                  <span className="text-sm font-medium tracking-wide text-primary transition-colors duration-300">
+                  <span className="text-[9px] md:text-sm font-medium tracking-wide text-primary transition-colors duration-300">
                     COMING SOON
                   </span>
                 </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3,8 +3,8 @@
 
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+ --background: #0a0a0a;
+    --foreground: #ededed;
 }
 
 


### PR DESCRIPTION
This commit implements a dark mode theme and adjusts the text size in the hero section for improved readability.

- **styles/globals.css:**
  - Updated the root CSS variables to implement a dark mode theme with a dark background and light foreground.

- **components/sections/hero.section.tsx:**
  - Reduced the text size of the "COMING SOON" label in the hero section for better visual balance. Adjusted text sizes for different screen sizes using `text-[9px] md:text-sm`.