### PR TITLE
feat: Update Pro plan tiers and features across the platform

### DIFF
--- a/components/sections/service.section.tsx
+++ b/components/sections/service.section.tsx
@@ -17,7 +17,7 @@ export function ServicesSection() {
 • Receive unlimited booking requests from hosts and agencies
 • Negotiate and manage bookings without leaving the platform
 • Track your success, views, and conversion rate with smart analytics (Pro+)
-• Get listed higher in searches and recommendations (Pro & Pro Max)`,
+• Get listed higher in searches and recommendations (Pro & Pro +)`,
       icon: (
         <div className="w-24 h-24 bg-primary flex items-center justify-center rounded-xl">
           <Music className="w-12 h-12 text-black" />
@@ -31,10 +31,10 @@ export function ServicesSection() {
       loginLink: "agency.hoizr.com/login",
       content: `• Manage and promote your artist roster with availability & stats
 • Apply to gigs on behalf of your artists (Free: 4/month, 1 artist only)
-• Approach and sign new artists (Pro: 3/month, Pro Max: unlimited)
+• Approach and sign new artists (Pro: 3/month, Pro +: unlimited)
 • Coordinate with hosts, negotiate bookings, and finalize deals in-app
 • Assign team members, manage roles and responsibilities
-• Run targeted campaigns and pitch decks (Pro & Pro Max)
+• Run targeted campaigns and pitch decks (Pro & Pro +)
 • Generate reports, commissions, and invoices from one dashboard`,
       icon: (
         <div className="w-24 h-24 bg-primary flex items-center justify-center rounded-xl">
@@ -52,8 +52,8 @@ export function ServicesSection() {
 • Apply to top artists or agencies directly (Free: 4 artists + 2 agencies/month)
 • Review portfolios, chat, negotiate, and confirm bookings in-app
 • Assign roles to co-hosts or collaborators (Pro+)
-• Publish public-facing event pages with ticketing via Hoizr Locale (Pro Max)
-• Unlock analytics, booking history, and competitive calendar insights (Pro Max)`,
+• Publish public-facing event pages with ticketing via Hoizr Locale (Pro +)
+• Unlock analytics, booking history, and competitive calendar insights (Pro +)`,
       icon: (
         <div className="w-24 h-24 bg-primary flex items-center justify-center rounded-xl">
           <Calendar className="w-12 h-12 text-black" />

--- a/pages/why-hoizr/index.tsx
+++ b/pages/why-hoizr/index.tsx
@@ -378,8 +378,7 @@ const ProFeatures = () => {
       </h2>
 
       <p className="text-xl text-gray-300 text-center max-w-3xl mx-auto mb-12">
-        With Hoizr Pro and Pro Max, nightlife professionals unlock advanced
-        tools:
+        With Hoizr Pro and Pro +, nightlife professionals unlock advanced tools:
       </p>
 
       <div className="max-w-4xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-6">


### PR DESCRIPTION
This commit updates the Pro plan tiers from "Pro Max" to "Pro +" and adjusts the corresponding features and descriptions across the platform.

- **pages/why-hoizr/index.tsx:**
  - Updated the Pro plan description to refer to "Pro +" instead of "Pro Max".

- **components/sections/service.section.tsx:**
  - Replaced "Pro Max" with "Pro +" in the descriptions of features available in the Pro plan for artists, agencies, and hosts.